### PR TITLE
Changing the tag name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zencashjs",
-  "version": "v1.1.9a",
+  "version": "v1.2.0",
   "description": "Dead easy to use Zencash JavaScript based library",
   "main": "./lib/index.js",
   "repository": "https://github.com/ZencashOfficial/zencashjs",


### PR DESCRIPTION
Hi, it seems like ` yarn` doesn't  recognize the version name that end with an `a`.
